### PR TITLE
feat: add Flutter SDK download URL generator

### DIFF
--- a/.cursor/rules/misc.mdc
+++ b/.cursor/rules/misc.mdc
@@ -12,6 +12,18 @@ alwaysApply: true
 - Use consistent terminology
 - Include examples where appropriate
 
+## Commit Messages
+- Write all commit messages in clear and concise English
+- Use conventional commits format: `<type>(<scope>): <subject>`
+- Types: feat, fix, docs, style, refactor, test, chore
+- Write subject in present tense and imperative mood
+- Keep subject line under 50 characters
+- Separate subject from body with a blank line
+- Wrap body at 72 characters
+- Use body to explain what and why, not how
+- Use bullet points for details
+- Reference issues and pull requests when applicable
+
 ## Markdown Files
 - Use proper Markdown syntax
 - Include a table of contents for long documents

--- a/.cursor/rules/misc.mdc
+++ b/.cursor/rules/misc.mdc
@@ -23,6 +23,10 @@ alwaysApply: true
 - Use body to explain what and why, not how
 - Use bullet points for details
 - Reference issues and pull requests when applicable
+- **When writing multi-line commit messages in the terminal, you must always use `$(printf ...)` to safely pass newlines and special characters. Do not use multiple -m options or other workarounds.**
+
+## Terminal Usage
+- **You must always use `$(printf ...)` when handling multi-line strings in the terminal (especially in Cursor) to safely pass newlines and special characters. Do not use multiple -m options or other workarounds.**
 
 ## Markdown Files
 - Use proper Markdown syntax


### PR DESCRIPTION
## Description

This PR adds a new function to generate Flutter SDK download URLs based on OS and architecture.

### Changes
- Add `generate_download_url` function to generate download URLs
- Support environments:
  - Linux x86_64
  - macOS x86_64
  - macOS ARM64
- Add test cases for each environment
- Add commit message rules to MDC

### Related Issue
Closes #161