### PR TITLE
chore(ci): move code coverage to ubuntu

### DIFF
--- a/.cursor/rules/misc.mdc
+++ b/.cursor/rules/misc.mdc
@@ -1,6 +1,6 @@
 ---
-description:
-globs:
+description: 
+globs: 
 alwaysApply: true
 ---
 # Miscellaneous Text Files Rules
@@ -11,6 +11,7 @@ alwaysApply: true
 - Keep documentation up-to-date
 - Use consistent terminology
 - Include examples where appropriate
+- **All content must be written in English only. No other languages are allowed.**
 
 ## Commit Messages
 - Write all commit messages in clear and concise English
@@ -27,6 +28,7 @@ alwaysApply: true
 
 ## Terminal Usage
 - **You must always use `$(printf ...)` when handling multi-line strings in the terminal (especially in Cursor) to safely pass newlines and special characters. Do not use multiple -m options or other workarounds.**
+- **When using GitHub CLI (gh), you must also use `$(printf ...)` for multi-line strings in the --body option to ensure proper formatting of PR descriptions and other multi-line content.**
 
 ## Markdown Files
 - Use proper Markdown syntax

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,7 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+          components: llvm-tools-preview
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -146,7 +147,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             skip-test: true
-            codecov: true
 
     runs-on: macos-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,18 @@ jobs:
           command: test
           args: --release --target ${{ matrix.target }} --locked
 
+      - name: Generate code coverage reports
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' && ! startsWith(github.ref, 'refs/tags/') && github.event_name != 'merge_group' }}
+        run: tools/coverage.sh
+
+      - name: Upload to Coveralls
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' && ! startsWith(github.ref, 'refs/tags/') && github.event_name != 'merge_group' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          format: lcov
+          files: coverage/tests.lcov
+
       - name: Pre-release
         if: |
           startsWith(github.repository, 'fenv-org') &&
@@ -182,18 +194,6 @@ jobs:
         with:
           command: test
           args: --release --target ${{ matrix.target }} --locked
-
-      - name: Generate code coverage reports
-        if: ${{ matrix.codecov }}
-        run: tools/coverage.sh
-
-      - name: Upload to Coveralls
-        if: ${{ matrix.codecov }}
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          format: lcov
-          files: coverage/tests.lcov
 
       - name: Pre-release
         if: |

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -13,7 +13,11 @@ function install_grcov() {
       export PATH=$bin_path:$PATH
     else
       grcov_version="v0.8.13"
-      url=https://github.com/mozilla/grcov/releases/download/$grcov_version/grcov-x86_64-apple-darwin.tar.bz2
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        url=https://github.com/mozilla/grcov/releases/download/$grcov_version/grcov-x86_64-apple-darwin.tar.bz2
+      else
+        url=https://github.com/mozilla/grcov/releases/download/$grcov_version/grcov-x86_64-unknown-linux-musl.tar.bz2
+      fi
       # url=$(curl -L \
       #   https://api.github.com/repos/mozilla/grcov/releases/latest 2> /dev/null \
       #   | jq --raw-output \


### PR DESCRIPTION
## Changes

- Move code coverage measurement from macOS to Ubuntu
- Skip coverage measurement for release builds and merge groups
- Use musl version of grcov binary