### PR TITLE
Remove pollution detection from flutter shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fenv"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fenv"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0"
 authors = ["fenv <fenv@jerry.company>"]
 license = "MIT license"
 description = "Simple flutter sdk version management"


### PR DESCRIPTION
## Summary

- Remove unreliable pollution detection logic from `shims/flutter`
- The shell-based version extraction was causing intermittent false alarms with Flutter 3.38+

## Related

- Fixes #210
- A more robust checksum-based approach will be implemented in #211 (milestone 0.4.0)